### PR TITLE
PrusaSlicer 2.3.1 uses "Horizontal shells"

### DIFF
--- a/calibration.html
+++ b/calibration.html
@@ -402,7 +402,7 @@
                     <td>3. Turn off top layers</td>
                     <td>Shell > Top/bottom thickness > Top layers: 0</td>
                     <td>Layer > Top solid layers: 0</td>
-                    <td>Print settings > Layers and perimeters > Horizontal layers > Top: 0</td>
+                    <td>Print settings > Layers and perimeters > Horizontal shells > Top: 0</td>
                 </tr>
                 <tr>
                     <td>4. Ensure wall thickness is a known value.<br />Substitute whatever values you like here. This example uses <b>0.4</b>, which is common for a 0.4mm nozzle and 0.2mm layer height.</td>


### PR DESCRIPTION
Change from "Horizontal layers" to "Horizontal shells".